### PR TITLE
Following PEP 263 to be more precisely

### DIFF
--- a/eradicate.py
+++ b/eradicate.py
@@ -52,7 +52,7 @@ def comment_contains_code(line, aggressive=True):
     if line.startswith('pylint:'):
         return False
 
-    if re.match(r'coding\s*[=:]', line):
+    if re.match(r'.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)', line):
         return False
 
     # Check that this is possibly code.

--- a/test_eradicate.py
+++ b/test_eradicate.py
@@ -137,10 +137,13 @@ class UnitTests(unittest.TestCase):
             '# coding=utf-8'))
 
         self.assertFalse(eradicate.comment_contains_code(
-            '#coding = utf-8'))
+            '#coding= utf-8'))
 
         self.assertFalse(eradicate.comment_contains_code(
             '# coding: utf-8'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# encoding: utf8'))
 
         self.assertTrue(eradicate.comment_contains_code(
             '# codings=utf-8'))


### PR DESCRIPTION
This PR aims to follow [PEP 263](https://www.python.org/dev/peps/pep-0263/) more precisely, especially for source code encoding hints.
According to PEP 263, encoding hints allow the following regular expression:

    ^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)

The regexp match `# encoding: utf8` which I often use but `eradicate 0.2.1` considered that the line contains code.

```con
$ eradicate tmp.py
 #!/usr/bin/python
-# encoding: utf8

...
```