### PR TITLE
Improve commented out code detection precision for multiline cases

### DIFF
--- a/eradicate.py
+++ b/eradicate.py
@@ -102,6 +102,10 @@ def multiline_case(line, aggressive=True):
         if re.search(r"def .+\)[\s]+->[\s]+[a-zA-Z_][a-zA-Z0-9_]*:$", line):
             return True
 
+        # Check weather a with statement
+        if re.search(r"with .+ as [a-zA-Z_][a-zA-Z0-9_]*:$", line):
+            return True
+
     if line.endswith('\\'):
         return True
 

--- a/eradicate.py
+++ b/eradicate.py
@@ -106,6 +106,10 @@ def multiline_case(line, aggressive=True):
         if re.search(r"with .+ as [a-zA-Z_][a-zA-Z0-9_]*:$", line):
             return True
 
+        # Check weather a for statement
+        if re.search(r"for [a-zA-Z_][a-zA-Z0-9_]* in .+:$", line):
+            return True
+
     if line.endswith('\\'):
         return True
 

--- a/eradicate.py
+++ b/eradicate.py
@@ -97,6 +97,11 @@ def multiline_case(line, aggressive=True):
             if line.strip() == ending + ',':
                 return True
 
+        # Check whether a function/method definition with return value
+        # annotation
+        if re.search(r"def .+\)[\s]+->[\s]+[a-zA-Z_][a-zA-Z0-9_]*:$", line):
+            return True
+
     if line.endswith('\\'):
         return True
 

--- a/test_eradicate.py
+++ b/test_eradicate.py
@@ -190,6 +190,14 @@ def foo():
 #
 """)))
 
+    def test_commented_out_code_line_numbers_with_for_statement(self):
+        self.assertEqual(
+            [1, 2],
+            list(eradicate.commented_out_code_line_numbers("""\
+# for x in y:
+#     foop = x.ham
+""")))
+
     def test_filter_commented_out_code(self):
         self.assertEqual(
             """\

--- a/test_eradicate.py
+++ b/test_eradicate.py
@@ -181,6 +181,15 @@ def foo():
     2
 """)))
 
+    def test_commented_out_code_line_numbers_with_with_statement(self):
+        self.assertEqual(
+            [1, 2],
+            list(eradicate.commented_out_code_line_numbers("""\
+# with open('filename', 'w') as outfile:
+#     json.dump(objects, outfile)
+#
+""")))
+
     def test_filter_commented_out_code(self):
         self.assertEqual(
             """\

--- a/test_eradicate.py
+++ b/test_eradicate.py
@@ -252,6 +252,24 @@ y = 1  # x = 3
             ''.join(eradicate.filter_commented_out_code(code,
                                                         aggressive=False)))
 
+    def test_filter_commented_out_code_with_annotation(self):
+        self.assertEqual(
+            '\n\n\n',
+            ''.join(eradicate.filter_commented_out_code("""\
+# class CommentedClass(object):
+#     def __init__(self, prop: int) -> None:
+#         self.property = prop
+
+#     def __str__(self) -> str:
+#         return self.__class__.__name__
+
+#    def set_prop(self, prop: int):
+#        self.prop = prop
+
+#    def get_prop(self):
+#        return self.prop
+""")))
+
     def test_detect_encoding_with_bad_encoding(self):
         with temporary_file('# -*- coding: blah -*-\n') as filename:
             self.assertEqual('latin-1',


### PR DESCRIPTION
This PR aims to improve precision especially for multiline cases.
Following cases will become detected precisely:

- Multi line with `with`/`for` statements: Issue #7
- Multi line with method return value annotation: Issue #8
