### PR TITLE
Make eradicate compatible with pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,5 @@
     description: "Apply eradicate"
     entry: eradicate
     language: python
-    files: "\.py$"
+    files: '\.py$'
     args: [--in-place]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,5 @@
     description: "Apply eradicate"
     entry: eradicate
     language: python
-    files: ''
+    files: "\.py$"
     args: [--in-place]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+-   id: eradicate
+    name: eradicate
+    description: "Apply eradicate"
+    entry: eradicate
+    language: python
+    files: ''
+    args: [--in-place]


### PR DESCRIPTION
Integrates [pre-commit](https://pre-commit.com/) with eradicate.  This makes it easy to configure and add eradicate as a pre-commit hook in your git repo.

For example, the [nbstripout](https://github.com/kynan/nbstripout) repo just merged a similar hook for that tool (for example in PR [79](https://github.com/kynan/nbstripout/pull/79)).