### PR TITLE
added whitelisting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ python:
 
 install:
     - python setup.py --quiet install
+    - pip --quiet install "mock; python_version>='2.7' and python_version<'2.8'"
 
 script:
     - python test_eradicate.py

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Whitelisting
 False positives can happen so there is a whitelist feature to fix them shorthand.
 You can either add entries to the default whitelist with ``--whitelist-extend`` or overwrite the default with ``--whitelist``.
 Both arguments expect a string of ``#`` separated regex strings (whitespaces are preserved). E.g. ``eradicate --whitelist "foo#b a r" filename``
-Those regex strings are matched against the start of the comment itself.
+Those regex strings are matched case insensitive against the start of the comment itself.
 
 For the default whitelist please see ``eradicate.py``.
 

--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,17 @@ After running ``eradicate``.
         return False
 
 
+Whitelisting
+============
+
+False positives can happen so there is a whitelist feature to fix them shorthand.
+You can either add entries to the default whitelist with ``--whitelist-extend`` or overwrite the default with ``--whitelist``.
+Both arguments expect a string of ``#`` separated regex strings (whitespaces are preserved). E.g. ``eradicate --whitelist "foo#b a r" filename``
+Those regex strings are matched against the start of the comment itself.
+
+For the default whitelist please see ``eradicate.py``.
+
+
 Related
 =======
 

--- a/eradicate.py
+++ b/eradicate.py
@@ -211,6 +211,17 @@ class Eradicator:
         except (SyntaxError, LookupError, UnicodeDecodeError):
             return 'latin-1'
 
+    def update_whitelist(self, new_whitelist, extend_default=True):
+        """Updates the whitelist."""
+        if extend_default:
+            self.WHITELIST_REGEX = re.compile(
+                r'|'.join(self.DEFAULT_WHITELIST + new_whitelist),
+                flags=re.IGNORECASE)
+        else:
+            self.WHITELIST_REGEX = re.compile(
+                r'|'.join(new_whitelist),
+                flags=re.IGNORECASE)
+
 
 def main(argv, standard_out, standard_error):
     """Main entry point."""
@@ -247,13 +258,9 @@ def main(argv, standard_out, standard_error):
     eradicator = Eradicator()
 
     if args.whitelist_extend:
-        eradicator.WHITELIST_REGEX = re.compile(
-            r'|'.join(eradicator.DEFAULT_WHITELIST + args.whitelist_extend.split('#')),
-            flags=re.IGNORECASE)
+        eradicator.update_whitelist(args.whitelist_extend.split('#'), True)
     elif args.whitelist:
-        eradicator.WHITELIST_REGEX = re.compile(
-            r'|'.join(args.whitelist.split('#')),
-            flags=re.IGNORECASE)
+        eradicator.update_whitelist(args.whitelist.split('#'), False)
 
     filenames = list(set(args.files))
     change_or_error = False

--- a/eradicate.py
+++ b/eradicate.py
@@ -38,7 +38,7 @@ class Eradicator(object):
     PARTIAL_DICTIONARY_REGEX = re.compile(r'^\s*[\'"]\w+[\'"]\s*:.+[,{]\s*$')
     CODING_COMMENT_REGEX = re.compile(r'.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)')
 
-    DEF_STATEMENT_REGEX = re.complie(r"def .+\)[\s]+->[\s]+[a-zA-Z_][a-zA-Z0-9_]*:$")
+    DEF_STATEMENT_REGEX = re.compile(r"def .+\)[\s]+->[\s]+[a-zA-Z_][a-zA-Z0-9_]*:$")
     WITH_STATEMENT_REGEX = re.compile(r"with .+ as [a-zA-Z_][a-zA-Z0-9_]*:$")
     FOR_STATEMENT_REGEX = re.compile(r"for [a-zA-Z_][a-zA-Z0-9_]* in .+:$")
 

--- a/eradicate.py
+++ b/eradicate.py
@@ -47,7 +47,7 @@ class Eradicator(object):
     CODE_KEYWORDS = [r'elif\s+.*', 'else', 'try', 'finally', r'except\s+.*']
     CODE_KEYWORDS_AGGR = CODE_KEYWORDS + [r'if\s+.*']
 
-    DEFAULT_WHITELIST = [
+    DEFAULT_WHITELIST = (
         r'pylint',
         r'pyright',
         r'noqa',
@@ -56,7 +56,7 @@ class Eradicator(object):
         r'TODO',
         r'FIXME',
         r'XXX'
-    ]
+    )
     WHITELIST_REGEX = re.compile(r'|'.join(DEFAULT_WHITELIST), flags=re.IGNORECASE)
 
     def comment_contains_code(self, line, aggressive=True):
@@ -220,7 +220,7 @@ class Eradicator(object):
         """Updates the whitelist."""
         if extend_default:
             self.WHITELIST_REGEX = re.compile(
-                r'|'.join(self.DEFAULT_WHITELIST + new_whitelist),
+                r'|'.join(list(self.DEFAULT_WHITELIST) + new_whitelist),
                 flags=re.IGNORECASE)
         else:
             self.WHITELIST_REGEX = re.compile(

--- a/eradicate.py
+++ b/eradicate.py
@@ -28,7 +28,6 @@ import difflib
 import io
 import os
 import re
-import sys
 import tokenize
 
 __version__ = '1.0'

--- a/eradicate.py
+++ b/eradicate.py
@@ -94,7 +94,7 @@ class Eradicator(object):
 
         line = re.sub(r'^(print|return)\b\s*', '', line)
 
-        if re.match(self.PARTIAL_DICTIONARY_REGEX, line):
+        if self.PARTIAL_DICTIONARY_REGEX.match(line):
             return True
 
         try:
@@ -117,21 +117,21 @@ class Eradicator(object):
 
             # Check whether a function/method definition with return value
             # annotation
-            if DEF_STATEMENT_REGEX.search(line):
+            if self.DEF_STATEMENT_REGEX.search(line):
                 return True
 
             # Check weather a with statement
-            if WITH_STATEMENT_REGEX.search(line):
+            if self.WITH_STATEMENT_REGEX.search(line):
                 return True
 
             # Check weather a for statement
-            if FOR_STATEMENT_REGEX.search(line):
+            if self.FOR_STATEMENT_REGEX.search(line):
                 return True
 
         if line.endswith('\\'):
             return True
 
-        if MULTILINE_ASSIGNMENT_REGEX.match(line):
+        if self.MULTILINE_ASSIGNMENT_REGEX.match(line):
             return True
 
         if re.match(r'^[()\[\]{}\s]+$', line):

--- a/eradicate.py
+++ b/eradicate.py
@@ -32,185 +32,184 @@ import tokenize
 
 __version__ = '1.0'
 
+class Eradicator:
+    """Eradicate comments."""
+    MULTILINE_ASSIGNMENT_REGEX = re.compile(r'^\s*\w+\s*=.*[(\[{]$')
+    PARTIAL_DICTIONARY_REGEX = re.compile(r'^\s*[\'"]\w+[\'"]\s*:.+[,{]\s*$')
 
-MULTILINE_ASSIGNMENT_REGEX = re.compile(r'^\s*\w+\s*=.*[(\[{]$')
-PARTIAL_DICTIONARY_REGEX = re.compile(r'^\s*[\'"]\w+[\'"]\s*:.+[,{]\s*$')
+    DEFAULT_WHITELIST = [
+        r'pylint',
+        r'pyright',
+        r'noqa',
+        r'type:\s*ignore',
+        r'fmt:\s*(on|off)',
+        r'TODO',
+        r'FIXME',
+        r'XXX'
+    ]
+    WHITELIST_REGEX = re.compile(r'|'.join(DEFAULT_WHITELIST), flags=re.IGNORECASE)
 
+    def comment_contains_code(self, line, aggressive=True):
+        """Return True comment contains code."""
+        line = line.lstrip()
+        if not line.startswith('#'):
+            return False
 
-DEFAULT_WHITELIST = [
-    r'pylint',
-    r'pyright',
-    r'noqa',
-    r'type:\s*ignore',
-    r'fmt:\s*(on|off)',
-    r'TODO',
-    r'FIXME',
-    r'XXX'
-]
-WHITELIST_REGEX = re.compile(r'|'.join(DEFAULT_WHITELIST), flags=re.IGNORECASE)
+        line = line.lstrip(' \t\v\n#').strip()
 
+        # Ignore non-comment related hashes. For example, "# Issue #999".
+        if re.search('#[0-9]', line):
+            return False
 
-def comment_contains_code(line, aggressive=True):
-    """Return True comment contains code."""
-    line = line.lstrip()
-    if not line.startswith('#'):
-        return False
+        # Ignore whitelisted comments
+        if self.WHITELIST_REGEX.search(line):
+            return False
 
-    line = line.lstrip(' \t\v\n#').strip()
+        if re.match(r'.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)', line):
+            return False
 
-    # Ignore non-comment related hashes. For example, "# Issue #999".
-    if re.search('#[0-9]', line):
-        return False
-
-    # Ignore whitelisted comments
-    if WHITELIST_REGEX.search(line):
-        return False
-
-    if re.match(r'.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)', line):
-        return False
-
-    # Check that this is possibly code.
-    for symbol in list('()[]{}:=%') + ['print', 'return', 'break', 'continue',
-                                       'import']:
-        if symbol in line:
-            break
-    else:
-        return False
-
-    if multiline_case(line, aggressive=aggressive):
-        return True
-
-    symbol_list = [r'elif\s+.*', 'else', 'try',
-                   'finally', r'except\s+.*']
-    if aggressive:
-        symbol_list.append(r'if\s+.*')
-
-    for symbol in symbol_list:
-        if re.match(r'^\s*' + symbol + r'\s*:\s*$', line):
-            return True
-
-    line = re.sub(r'^(print|return)\b\s*', '', line)
-
-    if re.match(PARTIAL_DICTIONARY_REGEX, line):
-        return True
-
-    try:
-        compile(line, '<string>', 'exec')
-        return True
-    except (SyntaxError, TypeError, UnicodeDecodeError):
-        return False
-
-
-def multiline_case(line, aggressive=True):
-    """Return True if line is probably part of some multiline code."""
-    if aggressive:
-        for ending in ')]}':
-            if line.endswith(ending + ':'):
-                return True
-
-            if line.strip() == ending + ',':
-                return True
-
-        # Check whether a function/method definition with return value
-        # annotation
-        if re.search(r"def .+\)[\s]+->[\s]+[a-zA-Z_][a-zA-Z0-9_]*:$", line):
-            return True
-
-        # Check weather a with statement
-        if re.search(r"with .+ as [a-zA-Z_][a-zA-Z0-9_]*:$", line):
-            return True
-
-        # Check weather a for statement
-        if re.search(r"for [a-zA-Z_][a-zA-Z0-9_]* in .+:$", line):
-            return True
-
-    if line.endswith('\\'):
-        return True
-
-    if re.match(MULTILINE_ASSIGNMENT_REGEX, line):
-        return True
-
-    if re.match(r'^[()\[\]{}\s]+$', line):
-        return True
-
-    return False
-
-
-def commented_out_code_line_numbers(source, aggressive=True):
-    """Yield line numbers of commented-out code."""
-    sio = io.StringIO(source)
-    try:
-        for token in tokenize.generate_tokens(sio.readline):
-            token_type = token[0]
-            start_row = token[2][0]
-            line = token[4]
-
-            if (token_type == tokenize.COMMENT and
-                    line.lstrip().startswith('#') and
-                    comment_contains_code(line, aggressive)):
-                yield start_row
-    except (tokenize.TokenError, IndentationError):
-        pass
-
-
-def filter_commented_out_code(source, aggressive=True):
-    """Yield code with commented out code removed."""
-    marked_lines = list(commented_out_code_line_numbers(source,
-                                                        aggressive))
-    sio = io.StringIO(source)
-    previous_line = ''
-    for line_number, line in enumerate(sio.readlines(), start=1):
-        if (line_number not in marked_lines or
-                previous_line.rstrip().endswith('\\')):
-            yield line
-        previous_line = line
-
-
-def fix_file(filename, args, standard_out):
-    """Run filter_commented_out_code() on file."""
-    encoding = detect_encoding(filename)
-    with open_with_encoding(filename, encoding=encoding) as input_file:
-        source = input_file.read()
-
-    filtered_source = ''.join(filter_commented_out_code(source,
-                                                        args.aggressive))
-
-    if source != filtered_source:
-        if args.in_place:
-            with open_with_encoding(filename, mode='w',
-                                    encoding=encoding) as output_file:
-                output_file.write(filtered_source)
+        # Check that this is possibly code.
+        for symbol in list('()[]{}:=%') + ['print', 'return', 'break', 'continue',
+                                           'import']:
+            if symbol in line:
+                break
         else:
-            diff = difflib.unified_diff(
-                source.splitlines(),
-                filtered_source.splitlines(),
-                'before/' + filename,
-                'after/' + filename,
-                lineterm='')
-            standard_out.write('\n'.join(list(diff) + ['']))
-        return True
+            return False
+
+        if self.multiline_case(line, aggressive=aggressive):
+            return True
+
+        symbol_list = [r'elif\s+.*', 'else', 'try',
+                       'finally', r'except\s+.*']
+        if aggressive:
+            symbol_list.append(r'if\s+.*')
+
+        for symbol in symbol_list:
+            if re.match(r'^\s*' + symbol + r'\s*:\s*$', line):
+                return True
+
+        line = re.sub(r'^(print|return)\b\s*', '', line)
+
+        if re.match(self.PARTIAL_DICTIONARY_REGEX, line):
+            return True
+
+        try:
+            compile(line, '<string>', 'exec')
+            return True
+        except (SyntaxError, TypeError, UnicodeDecodeError):
+            return False
 
 
-def open_with_encoding(filename, encoding, mode='r'):
-    """Return opened file with a specific encoding."""
-    return io.open(filename, mode=mode, encoding=encoding,
-                   newline='')  # Preserve line endings
+    def multiline_case(self, line, aggressive=True):
+        """Return True if line is probably part of some multiline code."""
+        if aggressive:
+            for ending in ')]}':
+                if line.endswith(ending + ':'):
+                    return True
+
+                if line.strip() == ending + ',':
+                    return True
+
+            # Check whether a function/method definition with return value
+            # annotation
+            if re.search(r"def .+\)[\s]+->[\s]+[a-zA-Z_][a-zA-Z0-9_]*:$", line):
+                return True
+
+            # Check weather a with statement
+            if re.search(r"with .+ as [a-zA-Z_][a-zA-Z0-9_]*:$", line):
+                return True
+
+            # Check weather a for statement
+            if re.search(r"for [a-zA-Z_][a-zA-Z0-9_]* in .+:$", line):
+                return True
+
+        if line.endswith('\\'):
+            return True
+
+        if re.match(self.MULTILINE_ASSIGNMENT_REGEX, line):
+            return True
+
+        if re.match(r'^[()\[\]{}\s]+$', line):
+            return True
+
+        return False
 
 
-def detect_encoding(filename):
-    """Return file encoding."""
-    try:
-        with open(filename, 'rb') as input_file:
-            from lib2to3.pgen2 import tokenize as lib2to3_tokenize
-            encoding = lib2to3_tokenize.detect_encoding(input_file.readline)[0]
+    def commented_out_code_line_numbers(self, source, aggressive=True):
+        """Yield line numbers of commented-out code."""
+        sio = io.StringIO(source)
+        try:
+            for token in tokenize.generate_tokens(sio.readline):
+                token_type = token[0]
+                start_row = token[2][0]
+                line = token[4]
 
-            # Check for correctness of encoding.
-            with open_with_encoding(filename, encoding) as input_file:
-                input_file.read()
+                if (token_type == tokenize.COMMENT and
+                        line.lstrip().startswith('#') and
+                        self.comment_contains_code(line, aggressive)):
+                    yield start_row
+        except (tokenize.TokenError, IndentationError):
+            pass
 
-        return encoding
-    except (SyntaxError, LookupError, UnicodeDecodeError):
-        return 'latin-1'
+
+    def filter_commented_out_code(self, source, aggressive=True):
+        """Yield code with commented out code removed."""
+        marked_lines = list(self.commented_out_code_line_numbers(source,
+                                                            aggressive))
+        sio = io.StringIO(source)
+        previous_line = ''
+        for line_number, line in enumerate(sio.readlines(), start=1):
+            if (line_number not in marked_lines or
+                    previous_line.rstrip().endswith('\\')):
+                yield line
+            previous_line = line
+
+
+    def fix_file(self, filename, args, standard_out):
+        """Run filter_commented_out_code() on file."""
+        encoding = self.detect_encoding(filename)
+        with self.open_with_encoding(filename, encoding=encoding) as input_file:
+            source = input_file.read()
+
+        filtered_source = ''.join(self.filter_commented_out_code(source,
+                                                            args.aggressive))
+
+        if source != filtered_source:
+            if args.in_place:
+                with self.open_with_encoding(filename, mode='w',
+                                        encoding=encoding) as output_file:
+                    output_file.write(filtered_source)
+            else:
+                diff = difflib.unified_diff(
+                    source.splitlines(),
+                    filtered_source.splitlines(),
+                    'before/' + filename,
+                    'after/' + filename,
+                    lineterm='')
+                standard_out.write('\n'.join(list(diff) + ['']))
+            return True
+
+
+    def open_with_encoding(self, filename, encoding, mode='r'):
+        """Return opened file with a specific encoding."""
+        return io.open(filename, mode=mode, encoding=encoding,
+                       newline='')  # Preserve line endings
+
+
+    def detect_encoding(self, filename):
+        """Return file encoding."""
+        try:
+            with open(filename, 'rb') as input_file:
+                from lib2to3.pgen2 import tokenize as lib2to3_tokenize
+                encoding = lib2to3_tokenize.detect_encoding(input_file.readline)[0]
+
+                # Check for correctness of encoding.
+                with self.open_with_encoding(filename, encoding) as input_file:
+                    input_file.read()
+
+            return encoding
+        except (SyntaxError, LookupError, UnicodeDecodeError):
+            return 'latin-1'
 
 
 def main(argv, standard_out, standard_error):
@@ -233,25 +232,26 @@ def main(argv, standard_out, standard_error):
                             'String of "#" separated comment beginnings to whitelist. '
                             'Single parts are interpreted as regex. '
                             'OVERWRITING the default whitelist: {}'
-                        ).format(DEFAULT_WHITELIST))
+                        ).format(Eradicator.DEFAULT_WHITELIST))
     parser.add_argument('--whitelist-extend', action="store",
                         help=(
                             'String of "#" separated comment beginnings to whitelist '
                             'Single parts are interpreted as regex. '
                             'Overwrites --whitelist. '
                             'EXTENDING the default whitelist: {} '
-                        ).format(DEFAULT_WHITELIST))
+                        ).format(Eradicator.DEFAULT_WHITELIST))
     parser.add_argument('files', nargs='+', help='files to format')
 
     args = parser.parse_args(argv[1:])
 
-    global WHITELIST_REGEX
+    eradicator = Eradicator()
+
     if args.whitelist_extend:
-        WHITELIST_REGEX = re.compile(
-            r'|'.join(DEFAULT_WHITELIST + args.whitelist_extend.split('#')),
+        eradicator.WHITELIST_REGEX = re.compile(
+            r'|'.join(eradicator.DEFAULT_WHITELIST + args.whitelist_extend.split('#')),
             flags=re.IGNORECASE)
     elif args.whitelist:
-        WHITELIST_REGEX = re.compile(
+        eradicator.WHITELIST_REGEX = re.compile(
             r'|'.join(args.whitelist.split('#')),
             flags=re.IGNORECASE)
 
@@ -268,7 +268,7 @@ def main(argv, standard_out, standard_error):
                                   if not d.startswith('.')]
         else:
             try:
-                change_or_error = fix_file(name, args=args, standard_out=standard_out) or change_or_error
+                change_or_error = eradicator.fix_file(name, args=args, standard_out=standard_out) or change_or_error
             except IOError as exception:
                 print('{}'.format(exception), file=standard_error)
                 change_or_error = True

--- a/test_eradicate.py
+++ b/test_eradicate.py
@@ -364,7 +364,7 @@ y = 1  # x = 3
         eradicator.update_whitelist(["foo"], True)
         self.assertTrue(
             eradicator.WHITELIST_REGEX == re.compile(
-                r'|'.join(eradicator.DEFAULT_WHITELIST + ["foo"]), flags=re.IGNORECASE
+                r'|'.join(list(eradicator.DEFAULT_WHITELIST) + ["foo"]), flags=re.IGNORECASE
             )
         )
 

--- a/test_eradicate.py
+++ b/test_eradicate.py
@@ -10,7 +10,10 @@ import subprocess
 import sys
 import tempfile
 import unittest
-import unittest.mock as mock
+try:
+    import unittest.mock as mock
+except ModuleNotFoundError:
+    import mock
 import re
 
 import eradicate

--- a/test_eradicate.py
+++ b/test_eradicate.py
@@ -17,203 +17,203 @@ import eradicate
 class UnitTests(unittest.TestCase):
 
     def test_comment_contains_code(self):
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '#'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# This is a (real) comment.'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# 123'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# 123.1'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# 1, 2, 3'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             'x = 1  # x = 1'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# pylint: disable=redefined-outer-name'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# Issue #999: This is not code'))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '# x = 1'))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '#from foo import eradicate'))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '#import eradicate'))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '#"key": value,'))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '#"key": "value",'))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '#"key": 1 + 1,'))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             "#'key': 1 + 1,"))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '#"key": {'))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '#}'))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '#} )]'))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '#},'))
 
     def test_comment_contains_code_with_print(self):
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '#print'))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '#print(1)'))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '#print 1'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '#to print'))
 
     def test_comment_contains_code_with_return(self):
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '#return x'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '#to return'))
 
     def test_comment_contains_code_with_multi_line(self):
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '#def foo():'))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '#else:'))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '#  else  :  '))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '# "foo %d" % \\'))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '#elif True:'))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '#x = foo('))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '#except Exception:'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# this is = to that :('))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '#else'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '#or else:'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '#else True:'))
 
     def test_comment_contains_code_with_sentences(self):
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '#code is good'))
 
     def test_comment_contains_code_with_encoding(self):
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# coding=utf-8'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '#coding= utf-8'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# coding: utf-8'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# encoding: utf8'))
 
-        self.assertTrue(eradicate.comment_contains_code(
+        self.assertTrue(eradicate.Eradicator().comment_contains_code(
             '# codings=utf-8'))
 
     def test_comment_contains_code_with_default_whitelist(self):
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# pylint: disable=A0123'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# pylint:disable=A0123'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# pylint: disable = A0123'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# pylint:disable = A0123'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# pyright: reportErrorName=true'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# noqa'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# NOQA'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# noqa: A123'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# noqa:A123'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# fmt: on'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# fmt: off'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# fmt:on'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# fmt:off'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# type: ignore'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# type:ignore'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# type: ignore[import]'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# type:ignore[import]'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# TODO: Do that'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# FIXME: Fix that'))
 
-        self.assertFalse(eradicate.comment_contains_code(
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# XXX: What ever'))
 
 
     def test_commented_out_code_line_numbers(self):
         self.assertEqual(
             [1, 3],
-            list(eradicate.commented_out_code_line_numbers(
+            list(eradicate.Eradicator().commented_out_code_line_numbers(
                 """\
 # print(5)
 # This is a comment.
@@ -228,7 +228,7 @@ y = 1  # x = 3
     def test_commented_out_code_line_numbers_with_errors(self):
         self.assertEqual(
             [1, 3],
-            list(eradicate.commented_out_code_line_numbers(
+            list(eradicate.Eradicator().commented_out_code_line_numbers(
                 """\
 # print(5)
 # This is a comment.
@@ -246,7 +246,7 @@ def foo():
     def test_commented_out_code_line_numbers_with_with_statement(self):
         self.assertEqual(
             [1, 2],
-            list(eradicate.commented_out_code_line_numbers("""\
+            list(eradicate.Eradicator().commented_out_code_line_numbers("""\
 # with open('filename', 'w') as out_file:
 #     json.dump(objects, out_file)
 #
@@ -255,7 +255,7 @@ def foo():
     def test_commented_out_code_line_numbers_with_for_statement(self):
         self.assertEqual(
             [1, 2],
-            list(eradicate.commented_out_code_line_numbers("""\
+            list(eradicate.Eradicator().commented_out_code_line_numbers("""\
 # for x in y:
 #     oops = x.ham
 """)))
@@ -270,7 +270,7 @@ y = 1  # x = 3
 # The below is another comment.
 # 3 / 2 + 21
 """,
-            ''.join(eradicate.filter_commented_out_code(
+            ''.join(eradicate.Eradicator().filter_commented_out_code(
                 """\
 # print(5)
 # This is a comment.
@@ -295,7 +295,7 @@ if False: \\
 """
         self.assertEqual(
             line,
-            ''.join(eradicate.filter_commented_out_code(line)))
+            ''.join(eradicate.Eradicator().filter_commented_out_code(line)))
 
     def test_filter_commented_out_code_with_larger_example(self):
         self.assertEqual(
@@ -307,7 +307,7 @@ y = 1  # x = 3
 # The below is another comment.
 # 3 / 2 + 21
 """,
-            ''.join(eradicate.filter_commented_out_code(
+            ''.join(eradicate.Eradicator().filter_commented_out_code(
                 """\
 # print(5)
 # This is a comment.
@@ -328,13 +328,13 @@ y = 1  # x = 3
 """
         self.assertEqual(
             code,
-            ''.join(eradicate.filter_commented_out_code(code,
+            ''.join(eradicate.Eradicator().filter_commented_out_code(code,
                                                         aggressive=False)))
 
     def test_filter_commented_out_code_with_annotation(self):
         self.assertEqual(
             '\n\n\n',
-            ''.join(eradicate.filter_commented_out_code("""\
+            ''.join(eradicate.Eradicator().filter_commented_out_code("""\
 # class CommentedClass(object):
 #     def __init__(self, prop: int) -> None:
 #         self.property = prop
@@ -352,7 +352,7 @@ y = 1  # x = 3
     def test_detect_encoding_with_bad_encoding(self):
         with temporary_file('# -*- coding: blah -*-\n') as filename:
             self.assertEqual('latin-1',
-                             eradicate.detect_encoding(filename))
+                             eradicate.Eradicator().detect_encoding(filename))
 
 
 class SystemTests(unittest.TestCase):

--- a/test_eradicate.py
+++ b/test_eradicate.py
@@ -148,6 +148,31 @@ class UnitTests(unittest.TestCase):
         self.assertTrue(eradicate.comment_contains_code(
             '# codings=utf-8'))
 
+    def test_comment_contains_code_with_default_whitelist(self):
+        self.assertFalse(eradicate.comment_contains_code('# pylint: disable=A0123'))
+        self.assertFalse(eradicate.comment_contains_code('# pylint:disable=A0123'))
+        self.assertFalse(eradicate.comment_contains_code('# pylint: disable = A0123'))
+        self.assertFalse(eradicate.comment_contains_code('# pylint:disable = A0123'))
+        self.assertFalse(eradicate.comment_contains_code('# pyright: reportErrorName=true'))
+        self.assertFalse(eradicate.comment_contains_code('# noqa'))
+        self.assertFalse(eradicate.comment_contains_code('# NOQA'))
+        self.assertFalse(eradicate.comment_contains_code('# noqa: A123'))
+        self.assertFalse(eradicate.comment_contains_code('# noqa:A123'))
+        self.assertFalse(eradicate.comment_contains_code('# fmt: on'))
+        self.assertFalse(eradicate.comment_contains_code('# fmt: off'))
+        self.assertFalse(eradicate.comment_contains_code('# fmt:on'))
+        self.assertFalse(eradicate.comment_contains_code('# fmt:off'))
+        self.assertFalse(eradicate.comment_contains_code('# type: ignore'))
+        self.assertFalse(eradicate.comment_contains_code('# type:ignore'))
+        self.assertFalse(eradicate.comment_contains_code('# type: ignore[import]'))
+        self.assertFalse(eradicate.comment_contains_code('# type:ignore[import]'))
+        self.assertFalse(eradicate.comment_contains_code('# TODO: Do that'))
+        self.assertFalse(eradicate.comment_contains_code('# FIXME: Fix that'))
+        self.assertFalse(eradicate.comment_contains_code('# XXX: What ever'))
+        self.assertTrue(eradicate.comment_contains_code('# todo: Do that'))
+        self.assertTrue(eradicate.comment_contains_code('# fixme: Fix that'))
+        self.assertTrue(eradicate.comment_contains_code('# xxx: What ever'))
+
     def test_commented_out_code_line_numbers(self):
         self.assertEqual(
             [1, 3],

--- a/test_eradicate.py
+++ b/test_eradicate.py
@@ -149,29 +149,66 @@ class UnitTests(unittest.TestCase):
             '# codings=utf-8'))
 
     def test_comment_contains_code_with_default_whitelist(self):
-        self.assertFalse(eradicate.comment_contains_code('# pylint: disable=A0123'))
-        self.assertFalse(eradicate.comment_contains_code('# pylint:disable=A0123'))
-        self.assertFalse(eradicate.comment_contains_code('# pylint: disable = A0123'))
-        self.assertFalse(eradicate.comment_contains_code('# pylint:disable = A0123'))
-        self.assertFalse(eradicate.comment_contains_code('# pyright: reportErrorName=true'))
-        self.assertFalse(eradicate.comment_contains_code('# noqa'))
-        self.assertFalse(eradicate.comment_contains_code('# NOQA'))
-        self.assertFalse(eradicate.comment_contains_code('# noqa: A123'))
-        self.assertFalse(eradicate.comment_contains_code('# noqa:A123'))
-        self.assertFalse(eradicate.comment_contains_code('# fmt: on'))
-        self.assertFalse(eradicate.comment_contains_code('# fmt: off'))
-        self.assertFalse(eradicate.comment_contains_code('# fmt:on'))
-        self.assertFalse(eradicate.comment_contains_code('# fmt:off'))
-        self.assertFalse(eradicate.comment_contains_code('# type: ignore'))
-        self.assertFalse(eradicate.comment_contains_code('# type:ignore'))
-        self.assertFalse(eradicate.comment_contains_code('# type: ignore[import]'))
-        self.assertFalse(eradicate.comment_contains_code('# type:ignore[import]'))
-        self.assertFalse(eradicate.comment_contains_code('# TODO: Do that'))
-        self.assertFalse(eradicate.comment_contains_code('# FIXME: Fix that'))
-        self.assertFalse(eradicate.comment_contains_code('# XXX: What ever'))
-        self.assertTrue(eradicate.comment_contains_code('# todo: Do that'))
-        self.assertTrue(eradicate.comment_contains_code('# fixme: Fix that'))
-        self.assertTrue(eradicate.comment_contains_code('# xxx: What ever'))
+        self.assertFalse(eradicate.comment_contains_code(
+            '# pylint: disable=A0123'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# pylint:disable=A0123'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# pylint: disable = A0123'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# pylint:disable = A0123'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# pyright: reportErrorName=true'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# noqa'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# NOQA'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# noqa: A123'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# noqa:A123'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# fmt: on'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# fmt: off'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# fmt:on'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# fmt:off'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# type: ignore'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# type:ignore'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# type: ignore[import]'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# type:ignore[import]'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# TODO: Do that'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# FIXME: Fix that'))
+
+        self.assertFalse(eradicate.comment_contains_code(
+            '# XXX: What ever'))
+
 
     def test_commented_out_code_line_numbers(self):
         self.assertEqual(

--- a/test_eradicate.py
+++ b/test_eradicate.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import re
 
 import eradicate
 
@@ -354,6 +355,20 @@ y = 1  # x = 3
             self.assertEqual('latin-1',
                              eradicate.Eradicator().detect_encoding(filename))
 
+    def test_extend_whitelist(self):
+        eradicator = eradicate.Eradicator()
+        eradicator.update_whitelist(["foo"], True)
+        self.assertTrue(
+            eradicator.WHITELIST_REGEX == re.compile(
+                r'|'.join(eradicator.DEFAULT_WHITELIST + ["foo"]), flags=re.IGNORECASE
+            )
+        )
+
+    def test_update_whitelist(self):
+        eradicator = eradicate.Eradicator()
+        eradicator.update_whitelist(["foo"], False)
+        self.assertTrue(eradicator.WHITELIST_REGEX == re.compile("foo", flags=re.IGNORECASE))
+
 
 class SystemTests(unittest.TestCase):
 
@@ -455,7 +470,6 @@ class SystemTests(unittest.TestCase):
                                standard_out=output_file,
                                standard_error=None)
             self.assertTrue(result is None)
-
 
     def test_end_to_end(self):
         with temporary_file("""\

--- a/test_eradicate.py
+++ b/test_eradicate.py
@@ -10,10 +10,10 @@ import subprocess
 import sys
 import tempfile
 import unittest
-try:
-    import unittest.mock as mock
-except ModuleNotFoundError:
+try:  # pragma: no cover
     import mock
+except ModuleNotFoundError:  # pragma: no cover
+    import unittest.mock as mock
 import re
 
 import eradicate

--- a/test_eradicate.py
+++ b/test_eradicate.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import unittest.mock as mock
 import re
 
 import eradicate
@@ -484,6 +485,26 @@ class SystemTests(unittest.TestCase):
 -# x * 3 == False
  # x is a variable
 """, '\n'.join(process.communicate()[0].decode().split('\n')[2:]))
+
+    def test_whitelist(self):
+        mock_update = mock.Mock()
+        with mock.patch.object(eradicate.Eradicator, 'update_whitelist', mock_update):
+            with temporary_file("# empty") as filename:
+                result = eradicate.main(argv=['my_fake_program', '--whitelist', 'foo# bar', filename],
+                                   standard_out=None,
+                                   standard_error=None)
+            self.assertTrue(result is None)
+            mock_update.assert_called_once_with(["foo", " bar"], False)
+
+    def test_whitelist_extend(self):
+        mock_update = mock.Mock()
+        with mock.patch.object(eradicate.Eradicator, 'update_whitelist', mock_update):
+            with temporary_file("# empty") as filename:
+                result = eradicate.main(argv=['my_fake_program', '--whitelist-extend', 'foo #bar', filename],
+                                   standard_out=None,
+                                   standard_error=None)
+            self.assertTrue(result is None)
+            mock_update.assert_called_once_with(["foo ", "bar"], True)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Multiple issues with false positives motivated me to add a whitelisting feature.

You can extend the default whitelist or overwrite it from command line.
Whitelist entries are interpreted as regex.

```python
WHITELIST = [
    r'pylint',
    r'pyright',
    r'(?i)noqa',
    r'type:\s*ignore',
    r'fmt:\s*(on|off)',
    r'TODO',
    r'FIXME',
    r'XXX'
]
```
Currently the regex check is case sensitive. A single entry can be made case insensitive by adding `(?i)` like above for `noqa`.

Maybe case insensitivity by default is okay?
What other defaults do you know that should be added?

I'm currently working on the tests and will also update the README afterwards.


Closes #19 PR for manually ignoring `TODO` which is covered by this PR

Fixes #25 
Fixes #24 
Fixes #16 
Fixes #15 
Fixes #11 
Resolves #26 

EDIT: Please see comment(s) below