### PR TITLE
Include tests in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include MANIFEST.in
 include README.rst
 exclude Makefile
-exclude test_eradicate.py


### PR DESCRIPTION
Hi,
Distributions such as Debian or Gentoo rely on PyPI tarballs to run tests.

This reverts part of 2a47d739a8cdf47a5c8f2cc47111ae3fec197399