### PR TITLE
setup.py: use setuptools instead of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from __future__ import unicode_literals
 
 import ast
-from distutils import core
+from setuptools import setup
 
 
 def version():
@@ -17,7 +17,7 @@ def version():
 
 
 with open('README.rst') as readme:
-    core.setup(
+    setup(
         name='eradicate',
         version=version(),
         description='Removes commented-out code.',


### PR DESCRIPTION
as distutils will be deprecated in python 3.12 and already produces
a warning when run with python 3.10.x, it might be a good time to
switch to setuptools.
It offers the same interface, so results will be the same

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>