### PR TITLE
Add mypy to the default whitelist

### DIFF
--- a/eradicate.py
+++ b/eradicate.py
@@ -57,6 +57,7 @@ class Eradicator(object):
         r'noqa',
         r'nosec',
         r'type:\s*ignore',
+        r'mypy:',
         r'fmt:\s*(on|off)',
         r'yapf:\s*(enable|disable)',
         r'isort:\s*(on|off|skip|skip_file|split|dont-add-imports(:\s*\[.*?\])?)',

--- a/test_eradicate.py
+++ b/test_eradicate.py
@@ -269,6 +269,15 @@ class UnitTests(unittest.TestCase):
             '# type:ignore[import]'))
 
         self.assertFalse(eradicate.Eradicator().comment_contains_code(
+            '# mypy: ignore-errors'))
+
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
+            '# mypy: disable-error-code=['))
+
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
+            '# mypy: warn-unreachable, strict-optional'))
+
+        self.assertFalse(eradicate.Eradicator().comment_contains_code(
             '# TODO: Do that'))
 
         self.assertFalse(eradicate.Eradicator().comment_contains_code(


### PR DESCRIPTION
This fixes handling of files that you want to ignore specific (or all) errors in mypy, as per https://mypy.readthedocs.io/en/stable/common_issues.html#ignoring-a-whole-file. They are treated as dead code otherwise, and an error is raised.