### PR TITLE
Actually include tests in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include MANIFEST.in
 include README.rst
 exclude Makefile
+include test_eradicate.py


### PR DESCRIPTION
Commit c53bdfbbf076a57a8fe76ffceeb8ec11d76285f2 removed the exclusion rule for tests from MANIFEST.in.  However, the tests would be only included if all files in the repository were included, e.g. if setuptools_scm was installed.  This doesn't seem to be the case here, so instead include the test file explicitly.

With this change:

    python -m build -s

produces an sdist that contains tests.